### PR TITLE
Bump Node.js version to 14 on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ on:
     branches: [ master ]
 
 jobs:
-  ci:
+  build-test:
+    name: Test Building
     runs-on: ubuntu-latest
 
     strategy:
@@ -29,8 +30,9 @@ jobs:
       run: yarn
     - name: Run build
       run: yarn build
-      
+
   build:
+    name: Build
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub Actions의 job에서 사용하는 Node.js의 버전을 14로 올렸습니다.