### PR TITLE
Replace namu.live into arca.live

### DIFF
--- a/interface/banned/namu_live.html
+++ b/interface/banned/namu_live.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>나무라이브 꺼라</title>
+    <title>아카라이브 꺼라</title>
     <style>
         @import url('https://fonts.googleapis.com/css?family=Noto+Sans+KR|Nunito&display=swap');
         body {

--- a/interface/popup/index.html
+++ b/interface/popup/index.html
@@ -189,11 +189,11 @@
         </div><br>
         <div class="search-filter">
             
-            <label class="switch-small to-right" for="namulive_block">
-                <input type="checkbox" id="namulive_block" data-val="namuLiveBlock">
+            <label class="switch-small to-right" for="arcalive_block">
+                <input type="checkbox" id="arcalive_block" data-val="arcaLiveBlock">
                 <span class="slider-small round"></span>
             </label>
-            <h3>나무라이브/나무뉴스 차단:</h3>
+            <h3>아카라이브/나무뉴스 차단:</h3>
         </div><br>
         <div class="search-filter">
             

--- a/src/banned.ts
+++ b/src/banned.ts
@@ -3,7 +3,7 @@
       const config = await browser.storage.sync.get() as unknown as ConfigInterface;
       console.log(`로드 완료. ${JSON.stringify(config)}`);
 
-      const accessingTo = config.namuLiveBlock ? "나무위키 또는 나무라이브, 나무뉴스" : "나무위키";
+      const accessingTo = config.arcaLiveBlock ? "나무위키 또는 아카라이브, 나무뉴스" : "나무위키";
 
       if (typeof config.bannedPageMessage !== "undefined") {
 

--- a/src/bg.ts
+++ b/src/bg.ts
@@ -10,7 +10,7 @@ async function loadConfig(): Promise<ConfigInterface> {
                 if (Object.keys(thisConfig).length === 0) {
                     await browser.storage.sync.set({
                         namuwikiBlock: true,
-                        namuLiveBlock: true,
+                        arcaLiveBlock: true,
                         namuMirrorBlock: true,
                         openRiss: true,
                         openDbpia: true,
@@ -92,7 +92,7 @@ browser.tabs.onUpdated.addListener(async (tabId, info, tab) => {
     const previousTabUrl = previousTabUrls[tabId];
     let config: ConfigInterface = await loadConfig();
 
-    let blockRules = getRules(config.namuMirrorBlock, config.namuLiveBlock);
+    let blockRules = getRules(config.namuMirrorBlock, config.arcaLiveBlock);
     let namuRules = getRules(true, false);
 
     adBlockNamuWiki = config.adBlockNamuWiki;
@@ -197,7 +197,7 @@ browser.tabs.onUpdated.addListener(async (tabId, info, tab) => {
                 
                 
 
-                if (config.namuLiveBlock && namuLiveAndNewsBlockRule.indexOf(rule) !== -1) {
+                if (config.arcaLiveBlock && arcaLiveAndNamuNewsBlockRule.indexOf(rule) !== -1) {
                     await browser.tabs.update(tabId, {
                         url: browser.extension.getURL(`interface/banned/namu_live.html?banned_url=${url}`),
                     });
@@ -253,9 +253,9 @@ const mirrorLists: PageBlockRule[] = [
     },
 ];
 
-const namuLiveAndNewsBlockRule: PageBlockRule[] = [
+const arcaLiveAndNamuNewsBlockRule: PageBlockRule[] = [
     {
-        baseURL: 'namu.live',
+        baseURL: 'arca.live',
         articleView: undefined,
         searchView: undefined
     },
@@ -274,7 +274,7 @@ function getRules(withMirror?: boolean, withNamuLiveNews?: boolean):PageBlockRul
         blockRules = blockRules.concat(mirrorLists);
     }
     if (withNamuLiveNews) {
-        blockRules = blockRules.concat(namuLiveAndNewsBlockRule);
+        blockRules = blockRules.concat(arcaLiveAndNamuNewsBlockRule);
 
     }
     return blockRules;
@@ -379,7 +379,7 @@ browser.webRequest.onBeforeRequest.addListener(
             "https://*.googlesyndication.com/*",
             "https://*.doubleclick.net/*",
             "https://adservice.google.com/*",
-            "https://namu.live/static/ad/*",
+            "https://arca.live/api/ads*",
             "https://searchad-phinf.pstatic.net/*",
             "https://ssl.pstatic.net/adimg3.search/*",
             "https://www.google.com/adsense/search/*",
@@ -399,7 +399,7 @@ browser.webRequest.onBeforeRequest.addListener(
  */
 browser.webRequest.onBeforeRequest.addListener(
     (details) => {
-        if (configCache.namuLiveBlock) {
+        if (configCache.arcaLiveBlock) {
             console.log("canceled!", "bwah bwah bwah!", details.url);
             return {
                 cancel: true
@@ -409,7 +409,7 @@ browser.webRequest.onBeforeRequest.addListener(
     {
         urls: [
             "https://search.namu.wiki/api/ranking",
-            "https://namu.live/*",
+            "https://arca.live/*",
             "https://namu.news/*",
             "https://namu.news/api/articles/cached",
         ]

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -11,7 +11,7 @@ interface ConfigInterface extends StorageObject{
     adBlockNamuWiki: boolean;
     proxyDbpia: string;
     filterSearch: boolean;
-    namuLiveBlock: boolean;
+    arcaLiveBlock: boolean;
     intelliBanEnabled: boolean;
     intelliBanUrl: string;
     intelliBanRules: {

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -6,7 +6,7 @@ const popup_settings = [
     document.getElementById('block_namumirror'),
     document.getElementById('adblock_namuwiki'),
     document.getElementById('filter_search'),
-    document.getElementById('namulive_block'),
+    document.getElementById('arcalive_block'),
     document.getElementById('intelliBan_enable'),
 ];
 


### PR DESCRIPTION
나무라이브가 "**아카라이브**"로 개명하여 URL이 **arca.live**로 바뀌었습니다. 따라서 이 확장기능이 아카라이브를 차단할 수 있도록 수정하였습니다.

(현재 기존 namu.live에서는 arca.live로 리다이렉트(`HTTP 301 Moved Permanently`) 처리가 되어있는 상태입니다.)

확인해주셨으면 하는 사항:

* 아카라이브 접속시 나타나는 안내문구(`src/banned.ts`)에서, 그냥 "아카라이브"라고 할지 아니면 "아카라이브(구 나무라이브)"같은 식으로 표기할지 고민하다가 그냥 아카라이브라고 적었습니다. 혹시 후자처럼 이전 이름을 적는 게 낫다고 보시나요?