### PR TITLE
fix: remove query check from duckduckgo regex

### DIFF
--- a/src/bg.ts
+++ b/src/bg.ts
@@ -357,7 +357,7 @@ const searchEngineRules: SearchEngineFilterRules[] = [
     },
     {
         name: 'DuckDuckGo',
-        regex: /^http(s|):\/\/(www.|search.|)duckduckgo.com\/\?q/ig,
+        regex: /^http(s|):\/\/(www.|search.|)duckduckgo.com\/\?/ig,
         scriptLocation: '/lib/filter/duckduckgo.js',
     },
     {


### PR DESCRIPTION
Firefox 주소창에서 `@duckduckgo 나무위키 꺼라` 입력 시 쿼리는 `?t=ffab&q=...`가 되는데, 현재 정규식은 쿼리가 `?q`로 시작하지 않을 경우 합치하지 않으므로 `triggerFilter()` 함수가 결과를 반환하지 않게 됩니다. 정규식을 수정해 쿼리의 존재만 인식하고 키를 확인하지 않게 하면 정상 작동합니다. 다른 정규식들도 쿼리의 존재만 인식하고 있으므로 일관성 또한 높입니다.

Fixes #59