### PR TITLE
DuckDuckGo 셀렉터 조정

### DIFF
--- a/src/filter/duckduckgo.ts
+++ b/src/filter/duckduckgo.ts
@@ -5,7 +5,7 @@
     const urlRegex = "^http(s?):\\/\\/";
     const blockRules = [ "namu.wiki", "namu.mirror.wiki", "namu.moe", "mir.pe", "namu.news" ];
 
-    const searchResultClasses = [ '.results article' ];
+    const searchResultClasses = [ 'nrn-react-div' ];
 
     let searchResults: HTMLDivElement[] = [];
 

--- a/src/filter/duckduckgo.ts
+++ b/src/filter/duckduckgo.ts
@@ -5,7 +5,7 @@
     const urlRegex = "^http(s?):\\/\\/";
     const blockRules = [ "namu.wiki", "namu.mirror.wiki", "namu.moe", "mir.pe", "namu.news" ];
 
-    const searchResultClasses = [ 'result' ];
+    const searchResultClasses = [ '.results article' ];
 
     let searchResults: HTMLDivElement[] = [];
 

--- a/src/filter/duckduckgo.ts
+++ b/src/filter/duckduckgo.ts
@@ -5,7 +5,7 @@
     const urlRegex = "^http(s?):\\/\\/";
     const blockRules = [ "namu.wiki", "namu.mirror.wiki", "namu.moe", "mir.pe", "namu.news" ];
 
-    const searchResultClasses = [ 'nrn-react-div' ];
+    const searchResultClasses = [ 'nrn-react-div', 'tile' ];
 
     let searchResults: HTMLDivElement[] = [];
 


### PR DESCRIPTION
검색 결과에 더이상 `result` 클래스가 존재하지 않으므로 조정합니다.